### PR TITLE
ci: renovate 起因の pr は pr への linter をしない設定が間違っていたので修正

### DIFF
--- a/.github/workflows/lint-pull-request.yml
+++ b/.github/workflows/lint-pull-request.yml
@@ -15,11 +15,14 @@ name: Lint PR
       - reopened
       - synchronize
       - edited
-    branches-ignore:
-      - 'renovate/**'
 
 jobs:
   lint-pr:
+    #
+    # PR 元が renovate 起因の場合、 job skip
+    # (renovate 起因の場合、ブランチ名は renovate/**)
+    #
+    if: ${{ !startsWith(github.head_ref, 'renovate/') }}
     runs-on: ubuntu-latest
     steps:
       - name: リポジトリのチェックアウト


### PR DESCRIPTION
## 全体的な意図 ( What, How )

- https://github.com/sunabak0/akiyadego-kotlin/pull/94

上記 PR の設定たが間違っていたので修正

## 追加・変更の文脈、位置づけ。なぜこの追加・変更が必要か ( Why )

そのままだとやりたかったこと ( renovate 起因の PR の linter 無視 ) が達成できない

## この PR がマージされると何が嬉しいか

今度こそ renovate 起因の pr が、 lint pr でコケることがなくなる

## 手動 QA 作業結果

renovate/sandbox-by-suna というブランチで PR を出し、 Lint PR が skip されることを確認しました

- その時の PR
  - https://github.com/sunabak0/akiyadego-kotlin/pull/100

<img width="400" alt="image" src="https://user-images.githubusercontent.com/43210698/210030281-d4fcf2c9-47dd-49ac-a0e3-8e6d2103ca00.png">


## Checklist

- [x] 手動 QA 作業をした 
- [x] 1 コミットあたりの差分をできるだけ小さくすることを意識した
- [ ] 追加・変更箇所に関わるテストケースを記述した
- [x] [コードレビューはつまらないから丁寧なプルリクエストでチームの生産性向上を目指す > レビュアーの負担を最小化すべき](https://blog.tai2.net/how-to-code-review.html#section-8) を一読し、実践した
- [ ] 特殊な理由のある変更など、コードだけから理解できなさそうな変更は、コメントに経緯を記述した

## 追加・変更したテストケースの見出し一覧

- 特に無し

## Issue

- #101

## レビュアーに手動 QA 作業してほしいですか

- [ ] QA 作業をして欲しい( MUST: QA 手順 )
  - [ ] 加えて、記述した手順も見て欲しい
- [x] QA 作業をしなくてもよい
  - [ ] ただ、記述した手順は見て欲しい

<details>
<summary><h2>QA 作業手順</h2></summary>

<!-- QA 手順を記述する場合、ここに記述しましょう -->

</details>

## レビューする時

- [レビュアーのときによく使うGitHubの便利機能](https://qiita.com/kata_1997/items/fd6cd3009e3d7704f984)

## コメントする時

以下のようなラベルをつけると温度感や、ざっくりと伝えたいことががわかります(小文字でも OK です。厳密な使い分けは不要です)

- MUST: 必ず修正・変更して欲しい
- WANT: できれば修正・変更して欲しい
- IMO: (In my opinion) 私の意見では
- IMHO: (In my humble opinion) 私のつたない意見では
- nits: (nitpick) ほんの小さな指摘。インデントミスなどの細かいところに。
- ASK: 質問。わからないことがあれば質問してみましょう。
- FYI: (For Your Informatio) 参考までに
- GOTCHA: やったぜ
- NP: 問題ない

## コピペ用絵文字

https://emojipedia.org/

😀：にっこり
😖：困った
🤔：むむ
<!-- textlint-disable ja-technical-writing/no-hankaku-kana,ja-technical-writing/no-exclamation-question-mark -->
👍：(・∀・)ｲｲﾈ!!
<!-- textlint-enable ja-technical-writing/no-hankaku-kana,ja-technical-writing/no-exclamation-question-mark -->
